### PR TITLE
Add in our first site: UsUncut

### DIFF
--- a/sites/blocked.json
+++ b/sites/blocked.json
@@ -1,3 +1,8 @@
 [
-  
+  {
+    "usuncut.com": {
+      "issue_id": 3,
+      "category": "clickbait"
+    }
+  }
 ]


### PR DESCRIPTION
## Site name

UsUncut.com

## Why?

Clickbait headlines, constant over exaggeration. 

## Example links

1. http://usuncut.com/news/bernie-sanders-just-blasted-democratic-party-trumps-victory/
2. http://usuncut.com/politics/dnc-mutiny-staffers-explode-donna-brazile/
3. http://usuncut.com/politics/bernie-sanders-would-have-crushed-trump/
